### PR TITLE
Restore ruled lines on .answer-lines; keep blank space scoped to .answer-box

### DIFF
--- a/app/assets/stylesheets/exam.css
+++ b/app/assets/stylesheets/exam.css
@@ -571,8 +571,13 @@ h1 {
 /* Lined answer space */
 
 .answer-lines {
-    /* Blank reserved writing space (no ruled lines — Louis's preference). */
-    background-image: none;
+    /* Ruled writing lines for prose answer space (short answer, markdown,
+       code-analysis, composite, etc). Calculation questions use the blank
+       .answer-box instead — Louis's "blank space for math" preference is
+       carried by that class, not by stripping lines globally. */
+    background-image: repeating-linear-gradient( to bottom, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) 6.65mm, rgba(0, 0, 0, 0.26) 6.65mm, rgba(0, 0, 0, 0.26) 7mm);
+    background-size: 100% 7mm;
+    /* Uniform stroke thickness; stable cadence. */
     min-height: 20mm;
     /* Keep the whole writing block together: better to bump to next page than
        to split the candidate's answer area across the page boundary. */


### PR DESCRIPTION
## Summary
- Revert the global `background-image: none` on `.answer-lines` introduced in 4a9c232.
- Calculation questions are unaffected: they render `.answer-box` (blank bordered box) + `.final-answer-line`, not `.answer-lines`.
- Prose-answer question types that do use `.answer-lines` (markdown, short-answer, code-analysis, composite) get ruled lines back.

## Why
In 4a9c232 I stripped the ruled-line background from `.answer-lines` to give math questions blank writing space. That was too broad — math questions never used `.answer-lines` in the first place, so stripping it silently removed lines from every prose-answer type. Louis spotted it.

## Test plan
- [ ] CI passes (rspec + bundle audit)
- [ ] After merge + deploy, regenerate a recent exam PDF and confirm short-answer/markdown questions render ruled lines while calculation questions still render a blank bordered box