### PR TITLE
Tier 1: serve OpenAPI spec at /api/openapi.{yaml,json}

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # README
 
 See docs/ONBOARDING.md for setup, architecture, and workflow details for Phase 1 of the exam generator.
+
+## API
+
+The OpenAPI 3.0.3 spec is served publicly (no auth required) at:
+
+- `https://selftesting.louisraymond.com/api/openapi.yaml` (YAML)
+- `https://selftesting.louisraymond.com/api/openapi.json` (JSON)
+
+The hand-maintained source lives at [`docs/openapi.yml`](docs/openapi.yml) and covers topics, modules, learning objectives, question bulk creation, and exam + PDF generation. All other `/api/*` endpoints require BasicAuth via `AUTH_USER` / `AUTH_PASSWORD`.

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Api
+  # Serves the canonical OpenAPI spec for test_generator over HTTP.
+  #
+  # Public endpoint — no BasicAuth. The auth bypass is declared in
+  # ApplicationController via the `unless:` lambda on
+  # `http_basic_authenticate_with` (any path starting with `/api/openapi`).
+  #
+  # Spec source is `docs/openapi.yml` (hand-maintained, the canonical spec).
+  # Once rswag-generated specs cover every endpoint (see
+  # `spec/swagger_helper.rb` — "rswag-generated specs will incrementally
+  # replace it"), this controller should switch to `swagger/v1/openapi.yaml`.
+  #
+  # Intentionally inherits from ApplicationController directly rather than
+  # Api::BaseController so we can serve YAML/JSON without the
+  # `request.format = :json` forcing and the JSON-specific rescue handlers
+  # that Api::BaseController adds.
+  class DocsController < ApplicationController
+    SPEC_PATH = Rails.root.join('docs/openapi.yml')
+
+    # Cache the parsed spec in memory — it's a fixed file read at boot time
+    # in production. Avoids disk IO on every request.
+    def self.spec
+      @spec ||= YAML.safe_load(File.read(SPEC_PATH), aliases: true)
+    end
+
+    def openapi
+      # Five-minute public cache so external tools (Postman import,
+      # openapi-generator, Swagger UI) don't hammer the endpoint.
+      response.set_header('Cache-Control', 'public, max-age=300')
+
+      case params[:format].to_s
+      when 'json'
+        render json: self.class.spec
+      else # 'yaml', 'yml', or default
+        render plain: self.class.spec.to_yaml, content_type: 'application/yaml'
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,8 @@ class ApplicationController < ActionController::Base
       # still require auth.
       unless: -> {
         request.path == "/up" ||
+          # Public OpenAPI spec + docs page (see Api::DocsController).
+          request.path.start_with?("/api/openapi", "/api/docs") ||
           request.path.match?(%r{\A/assets/.+-[a-f0-9]{8,}\.\w+\z}) ||
           request.path.match?(%r{\A/assets/.+\.\w+\z})
       }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,13 @@ Rails.application.routes.draw do
   resources :topics, only: %i[index show new create edit update]
 
   namespace :api do
+    # OpenAPI spec — public (no BasicAuth). Serves `docs/openapi.yml` as
+    # YAML by default, JSON on request. See Api::DocsController.
+    get 'openapi(.:format)', to: 'docs#openapi',
+                             defaults: { format: :yaml },
+                             constraints: { format: /yaml|yml|json/ },
+                             as: :openapi
+
     resources :topics, only: %i[create show index update destroy] do
       resources :learning_objectives, only: %i[create update destroy]
       resources :topic_modules, only: %i[create]

--- a/spec/requests/api/docs_spec.rb
+++ b/spec/requests/api/docs_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API OpenAPI docs endpoint', type: :request do
+  # Plain RSpec (not rswag) — the docs endpoint serves the OpenAPI spec
+  # itself, so we don't want to self-document it inside the generated spec.
+
+  describe 'GET /api/openapi.yaml' do
+    it 'serves the canonical OpenAPI spec as YAML' do
+      get '/api/openapi.yaml'
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with('application/yaml')
+      expect(response.body).to include('openapi: 3.0.3')
+      expect(response.body).to include('test_generator API')
+    end
+
+    it 'sets a public cache header' do
+      get '/api/openapi.yaml'
+      expect(response.headers['Cache-Control']).to include('public')
+      expect(response.headers['Cache-Control']).to include('max-age=300')
+    end
+  end
+
+  describe 'GET /api/openapi.yml' do
+    it 'also serves YAML under the .yml extension' do
+      get '/api/openapi.yml'
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with('application/yaml')
+      expect(response.body).to include('openapi: 3.0.3')
+    end
+  end
+
+  describe 'GET /api/openapi (no extension)' do
+    it 'defaults to YAML' do
+      get '/api/openapi'
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with('application/yaml')
+    end
+  end
+
+  describe 'GET /api/openapi.json' do
+    it 'serves the spec as JSON' do
+      get '/api/openapi.json'
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with('application/json')
+      parsed = JSON.parse(response.body)
+      expect(parsed['openapi']).to eq('3.0.3')
+      expect(parsed['info']['title']).to eq('test_generator API')
+    end
+  end
+
+end


### PR DESCRIPTION
## Summary
- Make the existing hand-maintained `docs/openapi.yml` reachable over HTTP at `/api/openapi.yaml` (default), `/api/openapi.yml`, and `/api/openapi.json`.
- Public endpoint (no BasicAuth). Auth bypass added to the existing `unless:` lambda in `ApplicationController` — narrow to `/api/openapi*` and `/api/docs*` only.
- 5-minute `Cache-Control: public, max-age=300` so external tools don't hammer the endpoint.

This is Tier 1 of the four-tier OpenAPI plan (see `Claude Plans/eager-wiggling-raven.md`). Tier 2 (Scalar docs UI), Postman sync, and Tier 3 (rswag-generated spec) follow as separate PRs.

## What this unlocks
- `curl https://selftesting.louisraymond.com/api/openapi.yaml` — canonical spec, no auth.
- `openapi-generator generate -i https://selftesting.louisraymond.com/api/openapi.yaml -g python …` — client codegen.
- Postman "Import from URL" against the endpoint.
- Claude's `WebFetch` + `postman:sync` skill now have a stable spec source.

## Notes
- Controller inherits from `ApplicationController` directly (not `Api::BaseController`) because `Api::BaseController#ensure_json` would force JSON format and prevent YAML responses.
- The lambda now also covers `/api/docs*` preemptively so Tier 2's static Scalar page at `public/api/docs.html` can drop in without touching auth again.
- Spec source remains `docs/openapi.yml` for now. Tier 3 will point this controller at the rswag-generated `swagger/v1/openapi.yaml` once request specs cover every endpoint.

## Test plan
- [ ] CI passes (RSpec + bundle-audit).
- [ ] After deploy: `curl https://selftesting.louisraymond.com/api/openapi.yaml | head` returns the YAML spec, no auth prompt.
- [ ] `curl https://selftesting.louisraymond.com/api/openapi.json | jq '.info.title'` returns `"test_generator API"`.
- [ ] `curl --netrc https://selftesting.louisraymond.com/api/topics` still requires auth (sanity — only `/api/openapi*` and `/api/docs*` are exempt).