### PR TITLE
Always render ruled writing space for markdown questions; document answer_size

### DIFF
--- a/app/views/questions/_markdown.html.erb
+++ b/app/views/questions/_markdown.html.erb
@@ -1,6 +1,8 @@
+<% size_class = question.answer_size.presence || 'short' %>
 <div class="markdown-body">
   <%= render_markdown(local_assigns[:content] || question.content) %>
-  <% if question.answer_size.present? %>
-    <div class="answer-lines answer-lines-<%= question.answer_size %>"></div>
-  <% end %>
+  <%# Always render ruled writing space for markdown questions; defaults to
+      'short' (25mm) when no answer_size is set. Same pattern as _code_analysis
+      and _composite. %>
+  <div class="answer-lines answer-lines-<%= size_class %>"></div>
 </div>

--- a/app/views/questions/_question.html.erb
+++ b/app/views/questions/_question.html.erb
@@ -39,10 +39,10 @@
       <% if body.present? %>
         <%= render 'questions/markdown', question: question, content: body %>
       <% else %>
-        <%# No fenced body; just show answer lines if requested %>
-        <% if question.answer_size.present? %>
-          <div class="answer-lines answer-lines-<%= size_class %>"></div>
-        <% end %>
+        <%# No fenced body — render a default ruled writing space. size_class
+            is defined at the top of this partial and defaults to 'short'
+            when answer_size is nil. %>
+        <div class="answer-lines answer-lines-<%= size_class %>"></div>
       <% end %>
     <% when 'composite' %>
       <%= render 'questions/composite', question: question %>

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -315,10 +315,29 @@ paths:
                       learning_objective_ids:
                         type: array
                         items: { type: integer }
-                      answer_size: { type: string }
+                      answer_size:
+                        type: string
+                        enum: [short, medium, long]
+                        nullable: true
+                        description: |
+                          Controls the height of the ruled writing space rendered below the question
+                          in exam PDFs. Applies to free-text question types (markdown, short_answer,
+                          calculation's working box, code_analysis, composite). Heights:
+                            - short  ≈ 25mm
+                            - medium ≈ 70mm
+                            - long   ≈ 140mm
+                          When omitted, defaults to 'short' at render time.
                       source_reference: { type: string }
-                      answer_label: { type: string }
-                      unit: { type: string }
+                      answer_label:
+                        type: string
+                        description: |
+                          Label shown next to the final-answer line in calculation questions (e.g. "x =", "t =").
+                          Defaults to "answer" when omitted. Ignored by other question types.
+                      unit:
+                        type: string
+                        description: |
+                          Unit string rendered after the final-answer line in calculation questions
+                          (e.g. "m/s", "kg"). Ignored by other question types.
       responses:
         '200':
           description: Questions created (possibly with partial errors)

--- a/spec/views/questions/_markdown.html.erb_spec.rb
+++ b/spec/views/questions/_markdown.html.erb_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'questions/_markdown', type: :view do
+  let(:question) do
+    build_stubbed(:question,
+                  question_type: 'markdown',
+                  answer_size: answer_size,
+                  content: 'Explain why entropy is a property of a distribution, not an outcome.')
+  end
+
+  def render_partial
+    render partial: 'questions/markdown', locals: { question: question }
+  end
+
+  describe 'ruled writing space' do
+    context 'when answer_size is nil' do
+      let(:answer_size) { nil }
+
+      it 'still renders an answer-lines div with the default short size' do
+        render_partial
+        expect(rendered).to have_css('.markdown-body .answer-lines.answer-lines-short')
+      end
+    end
+
+    context 'when answer_size is explicitly set' do
+      let(:answer_size) { 'long' }
+
+      it 'renders with the requested size class' do
+        render_partial
+        expect(rendered).to have_css('.markdown-body .answer-lines.answer-lines-long')
+      end
+    end
+
+    context 'when answer_size is medium' do
+      let(:answer_size) { 'medium' }
+
+      it 'renders with the medium size class' do
+        render_partial
+        expect(rendered).to have_css('.markdown-body .answer-lines.answer-lines-medium')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Completes the ruled-lines story.

**(A) View** — default `answer_size` to `'short'` for markdown questions so the `.answer-lines` div actually renders when no explicit size is set. PR #32 restored the ruled-line background on `.answer-lines`, but the markdown partial and the markdown-else branch of `_question.html.erb` gated the div itself on `answer_size.present?`, so any question seeded without an explicit size (including the 19 I bulk-seeded via the API earlier) rendered with zero writing space. New behaviour matches the already-tested defaulting in `_code_analysis.html.erb`.

**(B) OpenAPI** — enrich the `answer_size` schema entry on the bulk endpoint. The field was already accepted by `Api::QuestionsController#bulk` (SCALAR_FIELDS) and already listed in `docs/openapi.yml`, but only as a bare `{ type: string }`. Now it carries `enum: [short, medium, long]`, `nullable: true`, and a description naming the rendered heights (25/70/140 mm) and the render-time default. Also added descriptions to `answer_label` and `unit` while touching the schema.

Closes the "lines are still missing" follow-up.

## Test plan
- [ ] CI passes (RSpec + bundle-audit).
- [ ] New view spec covers nil-default + short/medium/long pass-through.
- [ ] After deploy, regenerate an exam from an existing markdown-heavy topic (e.g. topic 26, surprisal quiz exam 32) → every markdown question now shows a 25mm ruled writing area.
- [ ] `curl https://selftesting.louisraymond.com/api/openapi.yaml | grep -A2 answer_size` shows the documented enum.

## Files
- `app/views/questions/_markdown.html.erb` — drop `answer_size.present?` guard, default to `'short'`.
- `app/views/questions/_question.html.erb` — same, markdown-else branch.
- `docs/openapi.yml` — answer_size enum + description; answer_label/unit descriptions.
- `spec/views/questions/_markdown.html.erb_spec.rb` — new view spec.