### PR TITLE
Default to V2 topic detail; kill render-path N+1s (213 → 10 queries)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,11 +171,14 @@ jobs:
           # the user's last-visited surface; the topic detail page is
           # the meaningful canary. Add /topics back as a stable index
           # check.
-          check "/topics"        "$BASE/topics"               "Topics"
-          check "/topics/29"     "$BASE/topics/29"            "topic-detail"
-          check "/topics/29?v2"  "$BASE/topics/29?v2=1"       "topic-detail-v2"
-          check "v2 heatmap"     "$BASE/topics/29?v2=1"       "topic-heatmap"
-          check "v2 module"      "$BASE/topics/29?v2=1"       "topic-module"
+          check "/topics"        "$BASE/topics"                  "Topics"
+          # V2 is the default — the topic detail page must ship the V2
+          # wrapper, heat-map, and module-card markup with no flag.
+          check "/topics/29"     "$BASE/topics/29"               "topic-detail-v2"
+          check "v2 heatmap"     "$BASE/topics/29"               "topic-heatmap"
+          check "v2 module"      "$BASE/topics/29"               "topic-module"
+          # Legacy chrome stays reachable behind ?legacy=1 until we delete it.
+          check "legacy chrome"  "$BASE/topics/29?legacy=1"      "modules-grid"
           echo "Smoke OK."
 
   rollback:

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -7,10 +7,6 @@ class TopicsController < ApplicationController
 
   def show
     @exam_usage = LearningObjective.exam_appearance_counts_for(@topic.learning_objectives)
-    # sub-53 — Topic Detail v2 feature flag.  V2 chrome ships behind the
-    # `?v2=1` query param (per-request opt-in for QA) or `TOPIC_DETAIL_V2=true`
-    # ENV.  Once #54-#57 land we'll graduate this to a full flag library.
-    @topic_detail_v2 = helpers.topic_v2_enabled_for?(request)
   end
 
   def new

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -43,16 +43,25 @@ class TopicsController < ApplicationController
   def set_topic
     scope = Topic.all
     if action_name == 'show'
-      # Preload chain: subtopics for the back-link, modules + their LOs +
-      # link rows for the heat-map / coverage badges, top-level LOs and
-      # questions for the no-modules render path. Switching from
-      # `:questions` to `:question_learning_objectives` on the LO branches
-      # eliminates an N+1 over questions for the modules path while
-      # keeping `:questions` available where the no-modules legacy view
-      # still calls `obj.questions.size` (see Topic::LearningObjectiveManagement).
+      # Preload chain for the V2 default render path.
+      #
+      # LO branches preload `:question_learning_objectives` (the join row).
+      # The view layer reads question counts via `LearningObjective#question_count`,
+      # which uses the loaded join collection — see the model for why join-row
+      # count == questions count for this association.
+      #
+      # `topic_modules.questions` is a direct has_many (not :through), so it
+      # needs its own preload — `_module_card.html.erb` and `module_ministats`
+      # call `mod.questions.size` directly.
+      #
+      # Top-level `:learning_objectives` and `:questions` are preserved for the
+      # no-modules legacy render path (Topic::LearningObjectiveManagement).
       scope = scope.includes(
         :subtopics,
-        { topic_modules: { learning_objectives: :question_learning_objectives } },
+        { topic_modules: [
+          { learning_objectives: :question_learning_objectives },
+          :questions
+        ] },
         { learning_objectives: :question_learning_objectives },
         :questions
       )

--- a/app/helpers/topic_detail_helper.rb
+++ b/app/helpers/topic_detail_helper.rb
@@ -118,7 +118,7 @@ module TopicDetailHelper
   # `exam_usage` is the topic-wide hash from sub-52 ({lo_id => count}).
   # `mode` is 'questions' (default) or 'usage' — chooses initial text/colour.
   def lo_chip_html(lo, exam_usage:, mode: 'questions')
-    q_count = lo.questions.size
+    q_count = lo.question_count
     u_count = exam_usage.fetch(lo.id, 0)
 
     initial_value = mode == 'usage' ? u_count : q_count
@@ -167,8 +167,8 @@ module TopicDetailHelper
     end
 
     case sort
-    when :nq_desc then base.sort_by { |r| -r[:lo].questions.size }
-    when :nq_asc  then base.sort_by { |r| r[:lo].questions.size }
+    when :nq_desc then base.sort_by { |r| -r[:lo].question_count }
+    when :nq_asc  then base.sort_by { |r| r[:lo].question_count }
     when :alpha   then base.sort_by { |r| r[:lo].description.to_s.downcase }
     else               base
     end

--- a/app/helpers/topic_detail_helper.rb
+++ b/app/helpers/topic_detail_helper.rb
@@ -4,10 +4,9 @@
 #
 # Hosts the small string/format helpers used by the v2 sidebar, toolbar,
 # and stat strip partials, plus the feature-flag predicate that gates the
-# v2 markup behind a `?v2=1` query param or a `TOPIC_DETAIL_V2=true` ENV.
-#
-# Sub-issues #54-#57 will read these helpers; do not move them inline back
-# into the partials.
+# legacy markup behind a `?legacy=1` query param or a `TOPIC_DETAIL_LEGACY=true`
+# ENV.  V2 is the default; the flag exists so the old chrome stays reachable
+# while we phase the legacy controller flows out.
 module TopicDetailHelper
   # === sub-53: chrome ===
   # Renders a module's category / LO / question counts as the dot-separated
@@ -37,20 +36,20 @@ module TopicDetailHelper
     { label: label, value: value, html_data: html_data }
   end
 
-  # Feature-flag predicate.  V2 chrome ships behind `?v2=1` (per-request
-  # opt-in for QA) or a `TOPIC_DETAIL_V2=true` ENV (global opt-in for staging).
-  # Once #54-#57 land we'll graduate this to a real flag library.
-  def topic_detail_v2?(params_like)
-    return true if params_like.respond_to?(:[]) && params_like[:v2].to_s == '1'
+  # Feature-flag predicate.  V2 is the default; the legacy chrome ships
+  # behind `?legacy=1` (per-request opt-out) or a `TOPIC_DETAIL_LEGACY=true`
+  # ENV (global opt-out for staging).
+  def topic_detail_legacy?(params_like)
+    return true if params_like.respond_to?(:[]) && params_like[:legacy].to_s == '1'
 
-    ENV['TOPIC_DETAIL_V2'].to_s.downcase == 'true'
+    ENV['TOPIC_DETAIL_LEGACY'].to_s.downcase == 'true'
   end
 
   # Convenience wrapper that takes a request-like object (anything with
-  # `#params`) and forwards to `topic_detail_v2?`.  Lets controllers and
+  # `#params`) and forwards to `topic_detail_legacy?`.  Lets controllers and
   # views call the same predicate without re-extracting params.
-  def topic_v2_enabled_for?(request_like)
-    topic_detail_v2?(request_like.params)
+  def topic_legacy_enabled_for?(request_like)
+    topic_detail_legacy?(request_like.params)
   end
   # === /sub-53 ===
 

--- a/app/models/learning_objective.rb
+++ b/app/models/learning_objective.rb
@@ -8,6 +8,15 @@ class LearningObjective < ApplicationRecord
   validates :category, presence: true
   validates :description, presence: true
 
+  # Number of questions tied to this LO. Reads the join row directly
+  # because (question_id, learning_objective_id) is uniquely indexed
+  # (see QuestionLearningObjective), so the join-row count equals the
+  # questions count. Lets callers avoid the unpreloaded `:through`
+  # target when `question_learning_objectives` is already loaded.
+  def question_count
+    question_learning_objectives.size
+  end
+
   # Number of distinct exams that have included a question targeting this LO.
   # Returns 0 without touching exams when the LO has no questions.
   def exam_appearance_count

--- a/app/presenters/topic_heatmap_presenter.rb
+++ b/app/presenters/topic_heatmap_presenter.rb
@@ -51,7 +51,7 @@ class TopicHeatmapPresenter
       zeros = los.count { |lo| @exam_usage.fetch(lo.id, 0).zero? }
       { appearances: appearances, zero_count: zeros }
     else
-      { question_count: los.sum { |lo| lo.questions.size }, outcome_count: los.size }
+      { question_count: los.sum(&:question_count), outcome_count: los.size }
     end
   end
 
@@ -61,7 +61,7 @@ class TopicHeatmapPresenter
     cells = mod.learning_objectives.sort_by { |lo| [lo.position.to_i, lo.id] }.map do |lo|
       Cell.new(
         lo: lo,
-        coverage_count: lo.questions.size,
+        coverage_count: lo.question_count,
         utilization_count: @exam_usage.fetch(lo.id, 0)
       )
     end

--- a/app/views/topics/_view_categories.html.erb
+++ b/app/views/topics/_view_categories.html.erb
@@ -14,8 +14,8 @@
               data-lo-id="<%= row[:lo].id %>"
               data-lo-text="<%= row[:lo].description %>">
             <span class="topic-detail__m-tag mono">M<%= row[:module_idx].to_s.rjust(2, '0') %></span>
-            <span class="topic-detail__nq-chip" data-nq="<%= row[:lo].questions.size %>">
-              <%= row[:lo].questions.size %>
+            <span class="topic-detail__nq-chip" data-nq="<%= row[:lo].question_count %>">
+              <%= row[:lo].question_count %>
             </span>
             <span class="topic-detail__lo-text"><%= row[:lo].description %></span>
             <%= link_to '+ question',

--- a/app/views/topics/_view_outcomes_flat.html.erb
+++ b/app/views/topics/_view_outcomes_flat.html.erb
@@ -20,10 +20,10 @@
           data-outcome-row
           data-lo-id="<%= row[:lo].id %>"
           data-lo-text="<%= row[:lo].description %>"
-          data-nq="<%= row[:lo].questions.size %>"
+          data-nq="<%= row[:lo].question_count %>"
           data-topic-order="<%= row[:topic_order] %>">
         <span class="topic-detail__m-tag mono">M<%= row[:module_idx].to_s.rjust(2, '0') %></span>
-        <span class="topic-detail__nq-chip"><%= row[:lo].questions.size %></span>
+        <span class="topic-detail__nq-chip"><%= row[:lo].question_count %></span>
         <span class="topic-detail__lo-text"><%= row[:lo].description %></span>
         <span class="topic-detail__cat-tag mono"><%= row[:lo].category %></span>
         <%= link_to '+ question',

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,8 +1,9 @@
-<%# sub-53 — Topic detail orchestrator. %>
+<%# sub-53 — Topic detail orchestrator. V2 is the default; %>
+<%# `?legacy=1` (or TOPIC_DETAIL_LEGACY=true ENV) opts back into the legacy chrome. %>
 <%# %>
 <%# Partial ownership: %>
-<%#   _show_legacy       — preserved as-is for the flag-off path %>
-<%#   _show_v2           — sub-53 (this issue) %>
+<%#   _show_legacy       — opt-in via ?legacy=1 %>
+<%#   _show_v2           — default %>
 <%#     _topic_sidebar   — sub-53 %>
 <%#     _topic_toolbar   — sub-53 (search wired by sub-56) %>
 <%#     _stat_strip      — sub-53 (4th card swap by sub-3 / #52) %>
@@ -13,8 +14,8 @@
 <%#     _view_categories — sub-56 %>
 <%#     _view_outcomes_flat — sub-56 %>
 <%#     _search_empty    — sub-56 %>
-<% if topic_detail_v2?(params) %>
-  <%= render 'show_v2', topic: @topic, exam_usage: @exam_usage %>
-<% else %>
+<% if topic_detail_legacy?(params) %>
   <%= render 'show_legacy', topic: @topic %>
+<% else %>
+  <%= render 'show_v2', topic: @topic, exam_usage: @exam_usage %>
 <% end %>

--- a/spec/helpers/topic_detail_helper_spec.rb
+++ b/spec/helpers/topic_detail_helper_spec.rb
@@ -62,33 +62,33 @@ RSpec.describe TopicDetailHelper, type: :helper do
     end
   end
 
-  describe '#topic_detail_v2?' do
-    it 'returns true when params[:v2] is "1"' do
-      expect(helper.topic_detail_v2?(ActionController::Parameters.new(v2: '1'))).to be(true)
+  describe '#topic_detail_legacy?' do
+    it 'returns true when params[:legacy] is "1"' do
+      expect(helper.topic_detail_legacy?(ActionController::Parameters.new(legacy: '1'))).to be(true)
     end
 
-    it 'returns false when params[:v2] is missing' do
-      expect(helper.topic_detail_v2?(ActionController::Parameters.new)).to be(false)
+    it 'returns false when params[:legacy] is missing (V2 is the default)' do
+      expect(helper.topic_detail_legacy?(ActionController::Parameters.new)).to be(false)
     end
 
-    it 'returns true when ENV TOPIC_DETAIL_V2 is set to true' do
-      original = ENV['TOPIC_DETAIL_V2']
-      ENV['TOPIC_DETAIL_V2'] = 'true'
-      expect(helper.topic_detail_v2?(ActionController::Parameters.new)).to be(true)
+    it 'returns true when ENV TOPIC_DETAIL_LEGACY is set to true' do
+      original = ENV['TOPIC_DETAIL_LEGACY']
+      ENV['TOPIC_DETAIL_LEGACY'] = 'true'
+      expect(helper.topic_detail_legacy?(ActionController::Parameters.new)).to be(true)
     ensure
-      ENV['TOPIC_DETAIL_V2'] = original
+      ENV['TOPIC_DETAIL_LEGACY'] = original
     end
   end
 
-  describe '#topic_v2_enabled_for?' do
-    it 'mirrors topic_detail_v2? for now and accepts a request-like object' do
-      req = double('Request', params: ActionController::Parameters.new(v2: '1'))
-      expect(helper.topic_v2_enabled_for?(req)).to be(true)
+  describe '#topic_legacy_enabled_for?' do
+    it 'mirrors topic_detail_legacy? and accepts a request-like object' do
+      req = double('Request', params: ActionController::Parameters.new(legacy: '1'))
+      expect(helper.topic_legacy_enabled_for?(req)).to be(true)
     end
 
-    it 'returns false for a request without v2 param' do
+    it 'returns false for a request without legacy param' do
       req = double('Request', params: ActionController::Parameters.new)
-      expect(helper.topic_v2_enabled_for?(req)).to be(false)
+      expect(helper.topic_legacy_enabled_for?(req)).to be(false)
     end
   end
 

--- a/spec/models/learning_objective_spec.rb
+++ b/spec/models/learning_objective_spec.rb
@@ -1,6 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe LearningObjective, type: :model do
+  describe '#question_count' do
+    let(:topic) { create(:topic) }
+    let(:lo)    { create(:learning_objective, topic: topic) }
+
+    it 'returns 0 when the LO has no questions' do
+      expect(lo.question_count).to eq(0)
+    end
+
+    it 'matches questions.size for an LO with multiple questions' do
+      3.times { lo.questions << create(:question, topic: topic) }
+      lo.reload
+      expect(lo.question_count).to eq(lo.questions.size)
+      expect(lo.question_count).to eq(3)
+    end
+  end
+
   describe '#exam_appearance_count' do
     let(:topic) { create(:topic) }
     let(:lo)    { create(:learning_objective, topic: topic) }

--- a/spec/requests/topics_spec.rb
+++ b/spec/requests/topics_spec.rb
@@ -14,20 +14,20 @@ RSpec.describe 'Topics show', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    # Budget rationale: V2 is now the default chrome and renders heat-map
-    # cells, module cards with LO chips, and per-LO exam-usage callouts.
-    # Each of those introduces N+1 patterns the original sub-52 budget
-    # (≤ 18 queries on the legacy view) never had to cover. The spec
-    # comment that used to live here flagged this as the next optimization
-    # ("Sub-53 must drive this number DOWN by replacing `.count` with `.size`
-    # on the loaded collection, ideally hitting the original ≤ 6 target") —
-    # that optimization is the real fix and is tracked as a follow-up.
+    # Budget rationale: V2 is the default chrome. Rendering 4 modules,
+    # 28 LOs, and 112 questions costs ~10 queries:
     #
-    # Until that lands we hold the line at the V2 default's measured cost
-    # so future regressions still trip the budget. Run the spec locally
-    # and bump this number IF AND ONLY IF you can justify the extra
-    # queries; the goal is to drive it back down.
-    it 'issues no more than 220 SQL queries for a realistic topic on V2 default (follow-up: drive back to ≤ 18)' do
+    #   ~8 set_topic preloads (topic, subtopics, modules, modules.LOs,
+    #     modules.LOs.QLOs, modules.questions, top-level LOs, top-level
+    #     LOs.QLOs, top-level questions)
+    #   1 LearningObjective.exam_appearance_counts_for bulk fetch
+    #   ≈ 10 measured. Budget set to 12 to allow tiny variance.
+    #
+    # The view layer reads question counts via LearningObjective#question_count,
+    # which uses the already-preloaded `:question_learning_objectives` join —
+    # so per-LO `.size` calls are free. Bump this number IF AND ONLY IF
+    # you can justify the extra queries.
+    it 'issues no more than 12 SQL queries for a realistic topic' do
       # 4 modules x 7 LOs x ~4 questions/LO; some questions in exams
       4.times do |m_idx|
         mod = create(:topic_module, topic: topic, name: "Module #{m_idx}", position: m_idx)
@@ -48,7 +48,7 @@ RSpec.describe 'Topics show', type: :request do
       count = QueryCounter.count_for do
         get topic_path(topic)
       end
-      expect(count).to be <= 220, "expected <= 220 queries, got #{count}"
+      expect(count).to be <= 12, "expected <= 12 queries, got #{count}"
     end
   end
 end

--- a/spec/requests/topics_spec.rb
+++ b/spec/requests/topics_spec.rb
@@ -14,22 +14,20 @@ RSpec.describe 'Topics show', type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    # Budget rationale (sub-52 commit time, 4 modules × 7 LOs × 4 questions = 28 LOs,
-    # 112 questions, 10 questions across 3 exams):
+    # Budget rationale: V2 is now the default chrome and renders heat-map
+    # cells, module cards with LO chips, and per-LO exam-usage callouts.
+    # Each of those introduces N+1 patterns the original sub-52 budget
+    # (≤ 18 queries on the legacy view) never had to cover. The spec
+    # comment that used to live here flagged this as the next optimization
+    # ("Sub-53 must drive this number DOWN by replacing `.count` with `.size`
+    # on the loaded collection, ideally hitting the original ≤ 6 target") —
+    # that optimization is the real fix and is tracked as a follow-up.
     #
-    #   8 set_topic preloads (topic, subtopics, modules,
-    #     LOs-via-modules + qLOs, top-level LOs + qLOs, top-level questions)
-    #   1 LearningObjective.exam_appearance_counts_for (this ticket's bulk fetch)
-    #   8 view-layer count queries (2 per module: mod.learning_objectives.count
-    #     and mod.questions.count) — these belong to the heat-map redesign in
-    #     sub-53 and cannot be eliminated without changing app/views/topics/show.html.erb,
-    #     which is out of scope for this ticket per the file-ownership rules.
-    #   = 17 measured. Budget set to 18 to allow tiny variance.
-    #
-    # Sub-53 must drive this number DOWN by replacing `mod.learning_objectives.count`
-    # and `mod.questions.count` with size on the loaded collection, ideally hitting
-    # the original ≤ 6 target.
-    it 'issues no more than 18 SQL queries for a realistic topic' do
+    # Until that lands we hold the line at the V2 default's measured cost
+    # so future regressions still trip the budget. Run the spec locally
+    # and bump this number IF AND ONLY IF you can justify the extra
+    # queries; the goal is to drive it back down.
+    it 'issues no more than 220 SQL queries for a realistic topic on V2 default (follow-up: drive back to ≤ 18)' do
       # 4 modules x 7 LOs x ~4 questions/LO; some questions in exams
       4.times do |m_idx|
         mod = create(:topic_module, topic: topic, name: "Module #{m_idx}", position: m_idx)
@@ -50,7 +48,7 @@ RSpec.describe 'Topics show', type: :request do
       count = QueryCounter.count_for do
         get topic_path(topic)
       end
-      expect(count).to be <= 18, "expected <= 18 queries, got #{count}"
+      expect(count).to be <= 220, "expected <= 220 queries, got #{count}"
     end
   end
 end

--- a/spec/support/sub57_keyboard_helpers.rb
+++ b/spec/support/sub57_keyboard_helpers.rb
@@ -3,7 +3,7 @@
 # === sub-57: keyboard ===
 # Test-only helpers for the topic-keyboard system specs. After integration,
 # show.html.erb (sub-53) mounts the topic-keyboard controller and overlay
-# partial directly when ?v2=1 is set, so the original DOM-grafting in
+# partial directly (V2 is the default), so the original DOM-grafting in
 # `inject_keyboard_controller!` is no longer required for the mount itself.
 # The helper now only installs the window-level event recorder so specs can
 # assert dispatched events; it intentionally does NOT re-inject the overlay
@@ -35,7 +35,7 @@ module Sub57KeyboardHelpers
   # whole topic graph.
   #
   # Sub-53's show.html.erb mounts the topic-keyboard controller server-side
-  # when ?v2=1 is set; the overlay markup ships with it. This helper:
+  # by default (V2); the overlay markup ships with it. This helper:
   #   1. Locates the integrated controller mount.
   #   2. Updates its data-* values to match the test's intent.
   #   3. Re-emits a Stimulus reconnect by toggling data-controller, so the

--- a/spec/system/topics/heatmap_spec.rb
+++ b/spec/system/topics/heatmap_spec.rb
@@ -5,15 +5,15 @@ require 'rails_helper'
 # Integration follow-up: the original sub-54 spec drove a TEMP test-only
 # route (/spec_support/topic_heatmap/:topic_id) that took an `exam_usage`
 # query param so the JS could be exercised without seeding QuestionExam
-# rows. After integration the TEMP route is removed and `?v2=1` on the
-# real /topics/:id is the canonical entry point. The `exam_usage` data
-# now needs to be seeded via questions/exam fixtures rather than a query
-# param. Retargeting the URL alone is not sufficient — the assertions
-# need to be aligned with the seeds the real controller computes from
-# the DB. The original 6 specs have been collapsed into a single skip —
-# a follow-up will re-author them against the integrated route.
+# rows. After integration the TEMP route is removed and the real
+# /topics/:id (V2 default) is the canonical entry point. The `exam_usage`
+# data now needs to be seeded via questions/exam fixtures rather than a
+# query param. Retargeting the URL alone is not sufficient — the
+# assertions need to be aligned with the seeds the real controller
+# computes from the DB. The original 6 specs have been collapsed into a
+# single skip — a follow-up will re-author them against the integrated route.
 RSpec.describe 'Topic heat-map', type: :system, js: true do
-  it 'is pending — retarget heat-map system spec to /topics/:id?v2=1' do
-    skip 'follow-up: retarget heat-map system spec to /topics/:id?v2=1 with seeded exam usage'
+  it 'is pending — retarget heat-map system spec to /topics/:id' do
+    skip 'follow-up: retarget heat-map system spec to /topics/:id with seeded exam usage'
   end
 end

--- a/spec/system/topics/keyboard_overlay_spec.rb
+++ b/spec/system/topics/keyboard_overlay_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Topic detail keyboard overlay', type: :system, js: true do
   let!(:topic) { create(:topic, :with_modules) }
 
   def visit_topic_with_keyboard
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
     inject_keyboard_controller!(module_count: 2, active_module_index: 0)
     expect(page).to have_css('[data-controller~="topic-keyboard"]', visible: :all)
   end

--- a/spec/system/topics/keyboard_spec.rb
+++ b/spec/system/topics/keyboard_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Topic detail keyboard shortcuts', type: :system, js: true do
   let!(:topic) { create(:topic, :with_modules) }
 
   def visit_topic_with_keyboard(module_count: 2, active_module_index: 0)
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
     inject_keyboard_controller!(module_count: module_count, active_module_index: active_module_index)
     # Give Stimulus a moment to instantiate the controller.
     expect(page).to have_css('[data-controller~="topic-keyboard"]', visible: :all)

--- a/spec/system/topics/keyboard_toast_spec.rb
+++ b/spec/system/topics/keyboard_toast_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Topic detail keyboard first-visit toast', type: :system, js: tru
   let!(:topic) { create(:topic, :with_modules) }
 
   def visit_and_inject(clear_flag: true)
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
     clear_toast_seen_flag! if clear_flag
     inject_keyboard_controller!(module_count: 2, active_module_index: 0)
     expect(page).to have_css('[data-controller~="topic-keyboard"]', visible: :all)
@@ -42,7 +42,7 @@ RSpec.describe 'Topic detail keyboard first-visit toast', type: :system, js: tru
   end
 
   it 'subsequent visits (flag pre-seeded) do NOT show the toast' do
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
     seed_toast_seen_flag!
     inject_keyboard_controller!(module_count: 2, active_module_index: 0)
     expect(page).to have_css('[data-controller~="topic-keyboard"]', visible: :all)

--- a/spec/system/topics/legacy_still_works_spec.rb
+++ b/spec/system/topics/legacy_still_works_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-# Regression guard for sub-53.  When the v2 feature flag is off, the topic
-# detail page must render the legacy chrome unchanged so existing users
-# (and the existing topic_detail_controller form flows) keep working.
+# Regression guard for sub-53.  V2 is now the default; the legacy chrome
+# is still reachable via `?legacy=1` so existing users and the legacy
+# topic_detail_controller form flows keep working until we delete it.
 RSpec.describe 'Topic detail — legacy path (sub-53 regression)', type: :system do
   let!(:topic) do
     create(:topic, name: 'Thermal Physics', epigraph_quote: 'Truth is...').tap do |t|
@@ -14,8 +14,8 @@ RSpec.describe 'Topic detail — legacy path (sub-53 regression)', type: :system
     end
   end
 
-  it 'renders the legacy markup when v2 is off' do
-    visit topic_path(topic)
+  it 'renders the legacy markup when ?legacy=1 is set' do
+    visit topic_path(topic, legacy: 1)
     # Legacy chrome markers — these must still be on the page.
     expect(page).to have_css('.topic-detail.premium-page-wrapper')
     expect(page).to have_css('.topic-detail__back')

--- a/spec/system/topics/module_card_spec.rb
+++ b/spec/system/topics/module_card_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 # Integration follow-up: the inline Rack harness + `:sub55_js` driver tag
 # were temporary scaffolding while sub-55 was developed in parallel with
-# sub-53. Now that sub-53's show.html.erb mounts the V2 chrome (and
-# therefore mounts module_card), this spec should be rewritten to drive
-# the real `/topics/:id?v2=1` page. The harness, the bundled Stimulus from
-# CDN, and the bespoke driver registration are all now obsolete. The
+# sub-53. Now that sub-53's show.html.erb mounts the V2 chrome by default
+# (and therefore mounts module_card), this spec should be rewritten to
+# drive the real `/topics/:id` page. The harness, the bundled Stimulus
+# from CDN, and the bespoke driver registration are all now obsolete. The
 # original 8 specs have been collapsed into a single skip — a follow-up
 # will re-author them against the integrated page.
 RSpec.describe 'Topic V2 module card', type: :system do
-  it 'is pending — retarget module-card system spec to /topics/:id?v2=1' do
-    skip 'follow-up: retarget module-card system spec to /topics/:id?v2=1'
+  it 'is pending — retarget module-card system spec to /topics/:id' do
+    skip 'follow-up: retarget module-card system spec to /topics/:id'
   end
 end

--- a/spec/system/topics/v2_chrome_a11y_spec.rb
+++ b/spec/system/topics/v2_chrome_a11y_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Topic detail v2 chrome — a11y (sub-53)', type: :system, js: tr
     t
   end
 
-  before { visit topic_path(topic, v2: 1) }
+  before { visit topic_path(topic) }
 
   it 'wraps the module list in <nav aria-label="Topic outline">' do
     expect(page).to have_css('nav[aria-label="Topic outline"] ul.topic-detail__sidebar-list li')

--- a/spec/system/topics/v2_chrome_spec.rb
+++ b/spec/system/topics/v2_chrome_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Topic detail v2 chrome (sub-53)', type: :system, js: true do
 
   it 'renders the sidebar with topic name, epigraph, and module entries' do
     topic = build_topic_with_modules
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
 
     expect(page).to have_css('nav[aria-label="Topic outline"]')
     expect(page).to have_css('.topic-detail-v2__sidebar')
@@ -42,7 +42,7 @@ RSpec.describe 'Topic detail v2 chrome (sub-53)', type: :system, js: true do
 
   it 'shows MODULES · 0 and a + NEW MODULE CTA when topic has no modules' do
     topic = create(:topic, name: 'Empty Topic')
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
 
     expect(page).to have_css('.topic-detail__sidebar-modules-header', text: /MODULES · 0/)
     expect(page).to have_button('+ NEW MODULE')
@@ -50,7 +50,7 @@ RSpec.describe 'Topic detail v2 chrome (sub-53)', type: :system, js: true do
 
   it 'shows the stat strip with 4 cards' do
     topic = build_topic_with_modules
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
 
     expect(page).to have_css('.topic-detail__stat-card', count: 4)
     cards = page.all('.topic-detail__stat-card')
@@ -64,7 +64,7 @@ RSpec.describe 'Topic detail v2 chrome (sub-53)', type: :system, js: true do
 
   it 'shows the toolbar with search, +Outcome, +Module, ?' do
     topic = build_topic_with_modules
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
 
     expect(page).to have_css('input[placeholder="Search outcomes, categories, modules…"]')
     expect(page).to have_button('+ Outcome')
@@ -74,13 +74,13 @@ RSpec.describe 'Topic detail v2 chrome (sub-53)', type: :system, js: true do
 
   it 'renders the footer hint' do
     topic = build_topic_with_modules
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
     expect(page).to have_css('.topic-detail__footer-hint', text: /press \? for keyboard shortcuts/i)
   end
 
   it 'renders the skip-to-content link as the first focusable element' do
     topic = build_topic_with_modules
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
     expect(page).to have_css('a.topic-detail__skip-link', text: /Skip to main content/i, visible: :all)
     # The skip link must point at the main element id.
     expect(page).to have_css('a.topic-detail__skip-link[href="#topic-detail-main"]', visible: :all)
@@ -89,7 +89,7 @@ RSpec.describe 'Topic detail v2 chrome (sub-53)', type: :system, js: true do
 
   it 'sets aria-current on the clicked sidebar entry and scrolls main pane to that module' do
     topic = build_topic_with_modules
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
 
     third = topic.topic_modules[2]
     # Wait for Stimulus to connect (entry target binding implies the
@@ -115,7 +115,7 @@ RSpec.describe 'Topic detail v2 chrome (sub-53)', type: :system, js: true do
 
   it 'renders module sections in main pane with mod-{id} ids and tabindex on heading' do
     topic = build_topic_with_modules
-    visit topic_path(topic, v2: 1)
+    visit topic_path(topic)
     topic.topic_modules.each do |mod|
       expect(page).to have_css("##{ "mod-#{mod.id}" }")
     end

--- a/spec/views/topics/show_spec.rb
+++ b/spec/views/topics/show_spec.rb
@@ -14,10 +14,9 @@ RSpec.describe 'topics/show.html.erb', type: :view do
     assign(:exam_usage, nil)
   end
 
-  context 'when v2 flag is on' do
+  context 'by default (V2 is the default)' do
     it 'renders the v2 wrapper with sidebar and main' do
       controller.request.path_parameters[:id] = topic.id
-      params[:v2] = '1'
       render template: 'topics/show'
       expect(rendered).to have_css('.topic-detail-v2.premium-page-wrapper')
       expect(rendered).to have_css('aside.topic-detail-v2__sidebar')
@@ -27,9 +26,10 @@ RSpec.describe 'topics/show.html.erb', type: :view do
     end
   end
 
-  context 'when v2 flag is off' do
+  context 'when legacy flag is set' do
     it 'renders the legacy chrome' do
       controller.request.path_parameters[:id] = topic.id
+      params[:legacy] = '1'
       render template: 'topics/show'
       expect(rendered).to have_css('.topic-detail.premium-page-wrapper')
       expect(rendered).not_to have_css('.topic-detail-v2')


### PR DESCRIPTION
## Summary

- **Flip the V2 topic-detail flag** so `/topics/:id` ships V2 by default. Legacy chrome stays reachable behind `?legacy=1` (or `TOPIC_DETAIL_LEGACY=true` ENV) until the legacy controller flows are deleted. Helper renamed `topic_detail_v2?` → `topic_detail_legacy?` to reflect the new direction.
- **Kill the V2 render-path N+1s.** A realistic topic dropped from **213 → 10 queries** — beats the legacy view's 17 and crushes the original ≤ 18 target. Done with `LearningObjective#question_count` (reads the already-preloaded join row, no new preloads on the LO branch) plus a single new preload for `topic_modules.questions`.

The two commits are independently reversible:
- Reverting the perf commit alone restores V2 default + the relaxed 220 budget — still green.
- Reverting the flag-flip commit alone restores legacy default + the original ≤ 18 budget — still green.

## Test plan

- [x] `bundle exec rspec spec/helpers/topic_detail_helper_spec.rb spec/views/topics/ spec/models/learning_objective_spec.rb spec/system/topics/legacy_still_works_spec.rb` — all green
- [x] `bundle exec rspec spec/requests/topics_spec.rb` — query budget at 10 measured / ≤ 12 enforced
- [x] `bundle exec rspec spec/system/topics/v2_chrome_spec.rb spec/system/topics/v2_chrome_a11y_spec.rb` — 14/15 green (the one failure is a pre-existing aria-current flake on `main`, verified)
- [ ] CI smoke check confirms the new `topic-detail-v2` marker + `?legacy=1` reachability against the deployed instance after merge

## Out of scope (recommended follow-ups)

- `strict_loading!` on `@topic` so future N+1s fail loudly across every spec touching this route
- Lazy-load `_view_categories` and `_view_outcomes_flat` as Turbo Frames — they ship `hidden` but render server-side today
- Move data loading from the controller into `TopicHeatmapPresenter`