### PR TITLE
ci: fix smoke SIGPIPE false-positives + restore Kamal v2 rollback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,4 +235,9 @@ jobs:
             exit 1
           fi
           echo "Rolling back to $PREVIOUS_SHA"
-          kamal app rollback "$PREVIOUS_SHA"
+          # Kamal v2 doesn't have `kamal app rollback`. Equivalent is to
+          # re-run `kamal deploy` against the previous SHA; --skip-push tells
+          # Kamal not to rebuild/repush — the image for that SHA is already
+          # in the registry from its original deploy, so this just swaps the
+          # running container back.
+          kamal deploy --version="$PREVIOUS_SHA" --skip-push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,12 +154,18 @@ jobs:
             # -f makes 4xx/5xx fail loudly so we never treat an error page as
             # "smoke passed" just because grep happened to match.
             resp=$(curl -fLsS -u "$AUTH" "$url" -w '\n%{http_code}\n')
-            code=$(echo "$resp" | tail -n1)
+            # Use here-strings instead of `echo "$resp" | …`. `grep -q` exits
+            # the moment it finds the needle, which closes the pipe; the
+            # upstream `echo` then gets SIGPIPE and exits 141, and `set -o
+            # pipefail` propagates that as a pipeline failure — false-
+            # positive "marker missing". A here-string redirects the variable
+            # without spawning a pipe, so SIGPIPE never enters the picture.
+            code=$(tail -n1 <<< "$resp")
             if [ "$code" != "200" ]; then
               echo "::error::$label returned HTTP $code"
               return 1
             fi
-            if ! echo "$resp" | grep -q "$needle"; then
+            if ! grep -q "$needle" <<< "$resp"; then
               echo "::error::$label rendered but missing marker: $needle"
               return 1
             fi


### PR DESCRIPTION
## Summary

Two independent CI/CD bugs surfaced by the recent V2 deploy of #72.

- **Smoke check false-positives.** The post-deploy smoke piped curl output into `grep -q`. When the needle hits early in a large body, `grep -q` exits and SIGPIPEs the upstream `echo`, which `pipefail` propagates as a pipeline failure — the smoke then claims the marker is missing even when it isn't. That's what tripped on `/topics` (`<h1>Topics</h1>` is right at the top of the page). Switched to a here-string so no pipe is involved.
- **Auto-rollback non-functional.** The rollback step ran `kamal app rollback "$PREVIOUS_SHA"`, which hasn't existed since the Kamal v1→v2 upgrade. Every rollback attempt since then has died with `Could not find command "rollback"`. Replaced with `kamal deploy --version="$PREVIOUS_SHA" --skip-push` — the image for the previous SHA is already in the registry, so this just swaps containers back.

The two fixes are in separate, individually-reversible commits. The rollback fix is the more critical of the two — until it lands, a genuinely-bad deploy cannot be auto-recovered.

## Test plan

- [x] Local sanity check on the new shell logic — here-string returns 0 on match, 1 on miss; `tail -n1 <<<` extracts the http code correctly. SIGPIPE is impossible because there's no producer process to kill.
- [x] Confirmed Kamal v2 has `kamal deploy --version=<sha>` and `--skip-push` flags via `kamal help deploy`.
- [ ] Live CI run on this PR will exercise both fixes (smoke now passes; rollback path is only exercised on a real failure but the syntax is now valid).

## Notes

- The actual rollback path can't be safely tested without a deliberately broken deploy. Confidence comes from the command being valid Kamal v2 syntax and the `--skip-push` flag matching the documented behavior. If you want to canary it more aggressively, a follow-up could spike a `--dry-run`-style verification.