### PR TITLE
Add sectioned-exam-template API + switch PDF endpoints to modern layout

### DIFF
--- a/app/controllers/api/exam_templates_controller.rb
+++ b/app/controllers/api/exam_templates_controller.rb
@@ -1,0 +1,185 @@
+module Api
+  class ExamTemplatesController < BaseController
+    class ValidationError < StandardError; end
+
+    rescue_from ValidationError do |e|
+      render json: { error: e.message }, status: :unprocessable_entity
+    end
+
+    rescue_from ActiveRecord::RecordInvalid do |e|
+      render json: { error: e.message, errors: e.record.errors.full_messages }, status: :unprocessable_entity
+    end
+
+    rescue_from ExamBuilder::Error do |e|
+      render json: { error: e.message }, status: :unprocessable_entity
+    end
+
+    def index
+      templates = ExamTemplate.includes(:exam_sections).order(created_at: :desc)
+      render json: templates.map { |t| summary_payload(t) }
+    end
+
+    def show
+      template = ExamTemplate.includes(
+        exam_sections: [:section_source_rules, :section_question_rules]
+      ).find(params[:id])
+      render json: full_payload(template)
+    end
+
+    def create
+      attrs = exam_template_params
+      validate_request!(attrs)
+
+      template = nil
+      ActiveRecord::Base.transaction do
+        template = ExamTemplate.new(attrs)
+        template.save!
+      end
+
+      template.reload
+      render json: full_payload(template), status: :created
+    end
+
+    def generate
+      template = ExamTemplate.find(params[:id])
+      title = params[:title].presence
+      exam = ExamBuilder.from_template(
+        template_id: template.id,
+        title: title,
+        preserve_order: true
+      )
+
+      render json: {
+        exam_id: exam.id,
+        title: exam.title,
+        question_count: exam.exam_questions.count,
+        pdf_url: pdf_api_exam_path(exam),
+        marking_scheme_url: marking_scheme_pdf_api_exam_path(exam),
+        sections: template.exam_sections.order(:position).map { |s|
+          { position: s.position, name: s.name, question_count: s.question_count }
+        }
+      }, status: :created
+    end
+
+    private
+
+    def exam_template_params
+      params.require(:exam_template).permit(
+        :name,
+        :description,
+        :duration_minutes,
+        :subject,
+        :paper_number,
+        :tier,
+        :subtitle,
+        :rubric,
+        :centre_name,
+        :principles_of_marking,
+        :sections_have_letters,
+        candidate_fields: [],
+        grade_boundaries: {},
+        exam_sections_attributes: [
+          :id,
+          :name,
+          :position,
+          :question_count,
+          :duration_minutes,
+          :min_points,
+          :max_points,
+          :letter,
+          :_destroy,
+          { question_type_filter: [] },
+          { section_source_rules_attributes: %i[id source_type source_id weight question_count_override _destroy] },
+          { section_question_rules_attributes: %i[id question_id rule_type repeat_count _destroy] }
+        ]
+      )
+    end
+
+    def validate_request!(attrs)
+      sections = Array(attrs[:exam_sections_attributes])
+      sections.each do |section|
+        type_filter = Array(section[:question_type_filter]).reject(&:blank?)
+
+        Array(section[:section_question_rules_attributes]).each do |rule|
+          next if rule[:_destroy].present?
+          next unless rule[:rule_type] == 'force_include'
+
+          qid = rule[:question_id]
+          raise ValidationError, "Question #{qid} not found" unless qid.present?
+
+          q = Question.find_by(id: qid)
+          raise ValidationError, "Question #{qid} not found" unless q
+
+          next if type_filter.empty?
+          next if type_filter.include?(q.question_type.to_s)
+
+          raise ValidationError,
+                "Section '#{section[:name]}' force_includes question #{qid} of type " \
+                "'#{q.question_type}', which is not in question_type_filter " \
+                "#{type_filter.inspect}."
+        end
+      end
+    end
+
+    def summary_payload(template)
+      {
+        id: template.id,
+        name: template.name,
+        description: template.description,
+        total_questions: template.total_questions,
+        total_duration: template.total_duration,
+        sections_count: template.exam_sections.size,
+        use_count: template.use_count,
+        created_at: template.created_at,
+        updated_at: template.updated_at
+      }
+    end
+
+    def full_payload(template)
+      {
+        id: template.id,
+        name: template.name,
+        description: template.description,
+        duration_minutes: template.duration_minutes,
+        tier: template.tier,
+        subject: template.subject,
+        paper_number: template.paper_number,
+        total_questions: template.total_questions,
+        total_duration: template.total_duration,
+        use_count: template.use_count,
+        created_at: template.created_at,
+        updated_at: template.updated_at,
+        exam_sections: template.exam_sections.order(:position).map { |section|
+          {
+            id: section.id,
+            name: section.name,
+            position: section.position,
+            question_count: section.question_count,
+            duration_minutes: section.duration_minutes,
+            min_points: section.min_points,
+            max_points: section.max_points,
+            letter: section.letter,
+            question_type_filter: section.question_type_filter || [],
+            section_source_rules: section.section_source_rules.map { |r|
+              {
+                id: r.id,
+                source_type: r.source_type,
+                source_id: r.source_id,
+                weight: r.weight,
+                question_count_override: r.question_count_override
+              }
+            },
+            section_question_rules: section.section_question_rules.order(:id).map { |r|
+              {
+                id: r.id,
+                question_id: r.question_id,
+                rule_type: r.rule_type,
+                repeat_count: r.repeat_count
+              }
+            }
+          }
+        }
+      }
+    end
+  end
+end

--- a/app/controllers/api/exams_controller.rb
+++ b/app/controllers/api/exams_controller.rb
@@ -37,12 +37,16 @@ module Api
       render json: { error: e.message }, status: :unprocessable_entity
     end
 
+    # Default → modern `exams/paper` template (matches web UI). Legacy
+    # `exams/show` is preserved as an escape hatch via `?style=legacy` for
+    # any external client pinned to the old layout.
     def pdf
       @exam = Exam.includes(exam_questions: :question).find(params[:id])
       @font_size = params[:font_size]&.to_i || 14
       @question_spacing = params[:question_spacing]&.to_i || 18
 
-      html = render_to_string(template: 'exams/show', layout: 'pdf', formats: [:html])
+      template = params[:style].to_s == 'legacy' ? 'exams/show' : 'exams/paper'
+      html = render_to_string(template: template, layout: 'pdf', formats: [:html])
       pdf_data = PdfRenderer.render_to_pdf(html: html, base_url: request.base_url)
       send_data pdf_data, filename: "exam_#{@exam.id}.pdf", type: 'application/pdf'
     end
@@ -50,7 +54,8 @@ module Api
     def marking_scheme_pdf
       @exam = Exam.includes(exam_questions: :question).find(params[:id])
 
-      html = render_to_string(template: 'exams/marking_scheme', layout: 'pdf', formats: [:html])
+      template = params[:style].to_s == 'legacy' ? 'exams/marking_scheme' : 'exams/marker_paper'
+      html = render_to_string(template: template, layout: 'pdf', formats: [:html])
       pdf_data = PdfRenderer.render_to_pdf(html: html, base_url: request.base_url)
       send_data pdf_data, filename: "marking_scheme_#{@exam.id}.pdf", type: 'application/pdf'
     end

--- a/app/services/exam_builder.rb
+++ b/app/services/exam_builder.rb
@@ -4,25 +4,34 @@ class ExamBuilder
   class NotEnoughQuestionsError < Error; end
   class MissingSectionsError < Error; end
 
-  # Builds an exam from a template
-  def self.from_template(template_id:, title: nil)
+  # Builds an exam from a template.
+  #
+  # preserve_order: when true, force_include rules are inserted in rule-id
+  # order (i.e., the order they were created via the API), the section-final
+  # `shuffle` is skipped, and the generator raises if a section's force_include
+  # count exceeds its question_count. Used by the API path; defaults to false
+  # so the web UI keeps its existing shuffle behavior.
+  def self.from_template(template_id:, title: nil, preserve_order: false)
     template = ExamTemplate.find(template_id)
     raise MissingSectionsError, 'Template has no sections.' if template.exam_sections.empty?
-    
+
     title ||= "#{template.name} - #{Time.current.strftime('%Y-%m-%d')}"
-    
+
     ActiveRecord::Base.transaction do
+      duration = template.total_duration
+      duration = nil unless duration.to_i.positive? # Exam validates > 0 or nil
+
       exam = Exam.create!(
         title: title,
-        duration_minutes: template.total_duration,
+        duration_minutes: duration,
         exam_template_id: template.id
       )
-      
+
       position = 1
-      
+
       template.exam_sections.order(:position).each do |section|
-        questions = build_section_questions(section)
-        
+        questions = build_section_questions(section, preserve_order: preserve_order)
+
         questions.each do |question|
           exam.exam_questions.create!(
             question: question,
@@ -32,7 +41,7 @@ class ExamBuilder
           position += 1
         end
       end
-      
+
       template.increment_use_count!
       exam
     end
@@ -144,37 +153,53 @@ class ExamBuilder
     picked
   end
   
-  # Build questions for a specific section based on its rules
-  def self.build_section_questions(section)
-    questions = []
-    
-    # First, add all force-included questions (with repeats if specified)
-    section.section_question_rules.force_includes.includes(:question).each do |rule|
-      rule.repeat_count.times do
-        questions << rule.question
+  # Build questions for a specific section based on its rules.
+  #
+  # preserve_order: when true, force_includes are emitted in rule-id order,
+  # the final shuffle is skipped, and over-pinning (forced > question_count)
+  # raises. See ExamBuilder.from_template for context.
+  def self.build_section_questions(section, preserve_order: false)
+    forced_rules = section.section_question_rules.force_includes.order(:id).includes(:question)
+
+    forced = []
+    forced_rules.each do |rule|
+      type_filter = section.question_types
+      if type_filter.any? && rule.question.question_type.present? && !type_filter.include?(rule.question.question_type)
+        raise Error,
+              "Section '#{section.name}' force_includes question ##{rule.question_id} of " \
+              "type '#{rule.question.question_type}', which is not allowed by question_type_filter " \
+              "#{type_filter.inspect}."
       end
+      rule.repeat_count.times { forced << rule.question }
     end
-    
-    # Calculate how many more questions we need
-    remaining_count = section.question_count - questions.size
-    
+
+    if preserve_order && forced.size > section.question_count
+      raise Error,
+            "Section '#{section.name}' has #{forced.size} force_include rule(s) but " \
+            "question_count is #{section.question_count}. Reduce force_includes or " \
+            "raise question_count."
+    end
+
+    remaining_count = section.question_count - forced.size
+    filled = []
+
     if remaining_count > 0
-      # Get available questions from source rules
       available = section.available_questions
-      
-      # Apply weighted selection if multiple source rules
-      if section.section_source_rules.size > 1
-        selected = select_by_source_weights(section, available, remaining_count)
-      else
-        # Load to array first to avoid DISTINCT + RANDOM() conflict
-        selected = available.to_a.shuffle.take(remaining_count)
-      end
-      
-      questions.concat(selected)
+
+      filled = if section.section_source_rules.size > 1
+                 select_by_source_weights(section, available, remaining_count)
+               else
+                 # Load to array first to avoid DISTINCT + RANDOM() conflict
+                 available.to_a.shuffle.take(remaining_count)
+               end
     end
-    
-    # Shuffle to mix force-included with randomly selected
-    questions.shuffle
+
+    if preserve_order
+      # Pinned questions stay in their declared order; only the random fill is shuffled.
+      forced + filled.shuffle
+    else
+      (forced + filled).shuffle
+    end
   end
   
   # Select questions using weighted distribution across source rules

--- a/app/views/exams/marker_paper.html.erb
+++ b/app/views/exams/marker_paper.html.erb
@@ -9,7 +9,7 @@
   a free-text fallback block using their legacy `answer` column.
 %>
 
-<%= render 'ms_cover_page', exam: @exam %>
+<%= render 'exams/ms_cover_page', exam: @exam %>
 
 <%
   # Chunk questions into multiple .paper blocks so each sheet maps to

--- a/app/views/exams/paper.html.erb
+++ b/app/views/exams/paper.html.erb
@@ -37,7 +37,7 @@
   end
 %>
 
-<%= render 'cover_page', exam: @exam %>
+<%= render 'exams/cover_page', exam: @exam %>
 
 <% paper_pages.each_with_index do |pg, idx| %>
   <% section = pg[:section] %>
@@ -66,7 +66,7 @@
 
     <% pg[:questions].each do |eq| %>
       <% global_counter += 1 %>
-      <%= render 'paper_question', question: eq.question, counter: global_counter, exam_question: eq, editable: (@editable == true) %>
+      <%= render 'exams/paper_question', question: eq.question, counter: global_counter, exam_question: eq, editable: (@editable == true) %>
     <% end %>
 
     <div class="runfoot">

--- a/app/views/questions/_ranking.html.erb
+++ b/app/views/questions/_ranking.html.erb
@@ -13,7 +13,7 @@
     <tbody>
       <% items.each do |item| %>
         <tr>
-          <td class="ranking-item"><%= item %></td>
+          <td class="ranking-item"><%= item.is_a?(Hash) ? (item['text'] || item[:text]) : item %></td>
           <% scale.each do |_n| %>
             <td class="ranking-box"></td>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,12 @@ Rails.application.routes.draw do
         patch :autosave
       end
     end
+
+    resources :exam_templates, only: %i[create show index] do
+      member do
+        post :generate
+      end
+    end
   end
 
   if Rails.env.development?

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -76,6 +76,153 @@ components:
       properties:
         error: { type: string }
 
+    SectionSourceRuleInput:
+      type: object
+      required: [source_type, source_id]
+      properties:
+        source_type:
+          type: string
+          enum: [Topic, TopicModule, LearningObjective]
+        source_id: { type: integer }
+        weight:
+          type: integer
+          minimum: 1
+          default: 1
+        question_count_override:
+          type: integer
+          description: When set, this rule contributes exactly this many questions to the section, overriding weighted allocation.
+
+    SectionQuestionRuleInput:
+      type: object
+      required: [question_id, rule_type]
+      properties:
+        question_id: { type: integer }
+        rule_type:
+          type: string
+          enum: [force_include, exclude]
+        repeat_count:
+          type: integer
+          minimum: 1
+          default: 1
+          description: How many times the question is inserted (force_include only).
+
+    ExamSectionInput:
+      type: object
+      required: [name, position, question_count]
+      properties:
+        name: { type: string }
+        position:
+          type: integer
+          minimum: 0
+          description: Sort order within the template. Section A is position 0.
+        question_count:
+          type: integer
+          minimum: 1
+        duration_minutes: { type: integer }
+        min_points: { type: integer }
+        max_points: { type: integer }
+        letter:
+          type: string
+          description: Optional explicit section letter (defaults to A/B/C... from position).
+        question_type_filter:
+          type: array
+          description: Allowlist of question types this section accepts. Empty array = no filter.
+          items:
+            type: string
+        section_source_rules_attributes:
+          type: array
+          items: { $ref: '#/components/schemas/SectionSourceRuleInput' }
+        section_question_rules_attributes:
+          type: array
+          items: { $ref: '#/components/schemas/SectionQuestionRuleInput' }
+
+    ExamTemplateInput:
+      type: object
+      required: [exam_template]
+      properties:
+        exam_template:
+          type: object
+          required: [name, exam_sections_attributes]
+          properties:
+            name: { type: string }
+            description: { type: string }
+            duration_minutes: { type: integer }
+            subject: { type: string }
+            paper_number: { type: string }
+            tier:
+              type: string
+              enum: [foundation, higher, standard]
+            exam_sections_attributes:
+              type: array
+              items: { $ref: '#/components/schemas/ExamSectionInput' }
+
+    SectionSourceRule:
+      allOf:
+        - { $ref: '#/components/schemas/SectionSourceRuleInput' }
+        - type: object
+          properties:
+            id: { type: integer }
+
+    SectionQuestionRule:
+      allOf:
+        - { $ref: '#/components/schemas/SectionQuestionRuleInput' }
+        - type: object
+          properties:
+            id: { type: integer }
+
+    ExamSection:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        position: { type: integer }
+        question_count: { type: integer }
+        duration_minutes: { type: integer, nullable: true }
+        min_points: { type: integer, nullable: true }
+        max_points: { type: integer, nullable: true }
+        letter: { type: string, nullable: true }
+        question_type_filter:
+          type: array
+          items: { type: string }
+        section_source_rules:
+          type: array
+          items: { $ref: '#/components/schemas/SectionSourceRule' }
+        section_question_rules:
+          type: array
+          items: { $ref: '#/components/schemas/SectionQuestionRule' }
+
+    ExamTemplateResponse:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        description: { type: string, nullable: true }
+        duration_minutes: { type: integer, nullable: true }
+        tier: { type: string, nullable: true }
+        subject: { type: string, nullable: true }
+        paper_number: { type: string, nullable: true }
+        total_questions: { type: integer }
+        total_duration: { type: integer, nullable: true }
+        use_count: { type: integer }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+        exam_sections:
+          type: array
+          items: { $ref: '#/components/schemas/ExamSection' }
+
+    ExamTemplateSummary:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        description: { type: string, nullable: true }
+        total_questions: { type: integer }
+        total_duration: { type: integer, nullable: true }
+        sections_count: { type: integer }
+        use_count: { type: integer }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
 paths:
   /up:
     get:
@@ -454,7 +601,10 @@ paths:
   /api/exams/{id}/pdf:
     get:
       summary: Download exam as PDF
-      description: Renders via Chromium/Grover. May take 10-30 seconds.
+      description: |
+        Renders via Chromium/Grover. May take 10-30 seconds.
+        Defaults to the modern paper-style template (`exams/paper`).
+        Pass `?style=legacy` to fall back to the original `exams/show` layout.
       parameters:
         - name: id
           in: path
@@ -466,6 +616,13 @@ paths:
         - name: question_spacing
           in: query
           schema: { type: integer, default: 18 }
+        - name: style
+          in: query
+          description: '`modern` (default) renders the paper-style layout with section headers; `legacy` renders the original show template.'
+          schema:
+            type: string
+            enum: [modern, legacy]
+            default: modern
       responses:
         '200':
           description: PDF binary
@@ -479,6 +636,71 @@ paths:
   /api/exams/{id}/marking_scheme_pdf:
     get:
       summary: Download marking scheme as PDF
+      description: |
+        Defaults to the modern marker-paper layout (`exams/marker_paper`).
+        Pass `?style=legacy` to fall back to the original `exams/marking_scheme` layout.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer }
+        - name: style
+          in: query
+          description: '`modern` (default) or `legacy`.'
+          schema:
+            type: string
+            enum: [modern, legacy]
+            default: modern
+      responses:
+        '200':
+          description: PDF binary
+          content:
+            application/pdf: {}
+        '404':
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/exam_templates:
+    get:
+      summary: List exam templates
+      description: Returns a summary list ordered by `created_at` desc.
+      responses:
+        '200':
+          description: Array of exam-template summaries
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/ExamTemplateSummary' }
+
+    post:
+      summary: Create an exam template with sections and rules
+      description: |
+        Creates a sectioned `ExamTemplate` in a single nested payload. Each section can
+        filter the candidate pool by `question_type` and pin specific questions via
+        `force_include` rules (or remove them via `exclude` rules). Use `POST /api/exam_templates/{id}/generate`
+        to materialise an `Exam` from the template.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ExamTemplateInput' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ExamTemplateResponse' }
+        '422':
+          description: Validation error (e.g. force_include question's type isn't allowed by the section's question_type_filter, or referenced question_id does not exist)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/exam_templates/{id}:
+    get:
+      summary: Fetch a single exam template with its full nested structure
       parameters:
         - name: id
           in: path
@@ -486,9 +708,64 @@ paths:
           schema: { type: integer }
       responses:
         '200':
-          description: PDF binary
+          description: Exam template
           content:
-            application/pdf: {}
+            application/json:
+              schema: { $ref: '#/components/schemas/ExamTemplateResponse' }
+        '404':
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/exam_templates/{id}/generate:
+    post:
+      summary: Materialise an exam from a template
+      description: |
+        Generates an `Exam` from the template using `preserve_order: true` semantics —
+        `force_include` questions are inserted in the order their rules were created,
+        and section ordering is preserved. If a section's `force_include` count exceeds
+        its `question_count`, the call returns 422 (no silent truncation).
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: Optional exam title. Defaults to `"{template.name} - {today}"`.
+      responses:
+        '201':
+          description: Exam generated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  exam_id: { type: integer }
+                  title: { type: string }
+                  question_count: { type: integer }
+                  pdf_url: { type: string }
+                  marking_scheme_url: { type: string }
+                  sections:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        position: { type: integer }
+                        name: { type: string }
+                        question_count: { type: integer }
+        '422':
+          description: Generation failed (e.g. over-pinned section or type-filter mismatch)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
         '404':
           content:
             application/json:

--- a/spec/requests/api/exam_templates_spec.rb
+++ b/spec/requests/api/exam_templates_spec.rb
@@ -1,0 +1,287 @@
+require 'rails_helper'
+
+RSpec.describe 'API /api/exam_templates', type: :request do
+  let!(:topic) { create(:topic, name: 'API ExamTemplates Topic') }
+  let!(:topic_module) { create(:topic_module, topic: topic, name: 'API ETM') }
+
+  # 14 MCQ + 8 written + 4 composite = 26 hand-crafted questions
+  let!(:mcq_questions) do
+    14.times.map do |i|
+      create(:question, :multiple_choice, topic: topic, topic_module: topic_module,
+                                          content: "MCQ #{i}")
+    end
+  end
+  let!(:written_questions) do
+    8.times.map do |i|
+      create(:question, topic: topic, topic_module: topic_module,
+                        content: "Written #{i}", question_type: 'written')
+    end
+  end
+  let!(:composite_questions) do
+    4.times.map do |i|
+      create(:question, :composite, topic: topic, topic_module: topic_module,
+                                    content: "Composite #{i}")
+    end
+  end
+
+  def template_payload(name: 'Three-section template')
+    {
+      exam_template: {
+        name: name,
+        description: 'Sections A/B/C',
+        duration_minutes: 90,
+        exam_sections_attributes: [
+          {
+            name: 'Section A — Recognition',
+            position: 0,
+            question_count: 14,
+            question_type_filter: ['multiple_choice'],
+            section_source_rules_attributes: [
+              { source_type: 'TopicModule', source_id: topic_module.id, weight: 1 }
+            ],
+            section_question_rules_attributes: mcq_questions.map { |q|
+              { question_id: q.id, rule_type: 'force_include' }
+            }
+          },
+          {
+            name: 'Section B — Comprehension',
+            position: 1,
+            question_count: 8,
+            question_type_filter: ['written'],
+            section_source_rules_attributes: [
+              { source_type: 'TopicModule', source_id: topic_module.id, weight: 1 }
+            ],
+            section_question_rules_attributes: written_questions.map { |q|
+              { question_id: q.id, rule_type: 'force_include' }
+            }
+          },
+          {
+            name: 'Section C — Application & Synthesis',
+            position: 2,
+            question_count: 4,
+            question_type_filter: ['composite'],
+            section_source_rules_attributes: [
+              { source_type: 'TopicModule', source_id: topic_module.id, weight: 1 }
+            ],
+            section_question_rules_attributes: composite_questions.map { |q|
+              { question_id: q.id, rule_type: 'force_include' }
+            }
+          }
+        ]
+      }
+    }
+  end
+
+  describe 'POST /api/exam_templates' do
+    it 'creates a template with nested sections and rules (201)' do
+      expect {
+        post '/api/exam_templates',
+             params: template_payload.to_json,
+             headers: { 'CONTENT_TYPE' => 'application/json' }
+      }.to change(ExamTemplate, :count).by(1)
+        .and change(ExamSection, :count).by(3)
+        .and change(SectionQuestionRule, :count).by(26)
+        .and change(SectionSourceRule, :count).by(3)
+
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json['id']).to be_present
+      expect(json['name']).to eq('Three-section template')
+      expect(json['exam_sections'].size).to eq(3)
+      expect(json['exam_sections'].first['section_question_rules'].size).to eq(14)
+    end
+
+    it 'returns 422 when a force_include question_type does not match the section filter' do
+      payload = template_payload(name: 'Bad type filter')
+      payload[:exam_template][:exam_sections_attributes][0][:section_question_rules_attributes] = [
+        { question_id: written_questions.first.id, rule_type: 'force_include' }
+      ]
+
+      expect {
+        post '/api/exam_templates',
+             params: payload.to_json,
+             headers: { 'CONTENT_TYPE' => 'application/json' }
+      }.not_to change(ExamTemplate, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      json = JSON.parse(response.body)
+      expect(json['error']).to match(/question.*type|type.*filter/i)
+    end
+
+    it 'returns 422 when a force_include question_id does not exist' do
+      payload = template_payload(name: 'Missing question')
+      payload[:exam_template][:exam_sections_attributes][0][:section_question_rules_attributes] = [
+        { question_id: 99_999_999, rule_type: 'force_include' }
+      ]
+
+      post '/api/exam_templates',
+           params: payload.to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      json = JSON.parse(response.body)
+      expect(json['error']).to match(/question.*99999999.*not.*found/i)
+    end
+  end
+
+  describe 'GET /api/exam_templates/:id' do
+    it 'returns the full nested structure' do
+      post '/api/exam_templates',
+           params: template_payload(name: 'For show').to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+      id = JSON.parse(response.body).fetch('id')
+
+      get "/api/exam_templates/#{id}"
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json['id']).to eq(id)
+      expect(json['exam_sections'].size).to eq(3)
+      expect(json['exam_sections'].map { |s| s['question_count'] }).to eq([14, 8, 4])
+      expect(json['exam_sections'][0]['section_question_rules'].size).to eq(14)
+      expect(json['exam_sections'][0]['section_source_rules'].size).to eq(1)
+    end
+
+    it 'returns 404 for an unknown id' do
+      get '/api/exam_templates/99999999'
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'GET /api/exam_templates' do
+    it 'returns a summary list ordered by created_at desc' do
+      post '/api/exam_templates',
+           params: template_payload(name: 'First').to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+      post '/api/exam_templates',
+           params: template_payload(name: 'Second').to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+
+      get '/api/exam_templates'
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json).to be_an(Array)
+      expect(json.map { |t| t['name'] }).to eq(['Second', 'First'])
+      expect(json.first).to include('id', 'name', 'total_questions', 'sections_count')
+      expect(json.first['total_questions']).to eq(26)
+      expect(json.first['sections_count']).to eq(3)
+    end
+  end
+
+  describe 'POST /api/exam_templates/:id/generate' do
+    let(:template_id) do
+      post '/api/exam_templates',
+           params: template_payload(name: 'For generate').to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+      JSON.parse(response.body).fetch('id')
+    end
+
+    it 'materialises an exam with section_number per question and preserves force_include order' do
+      expect {
+        post "/api/exam_templates/#{template_id}/generate",
+             params: {}.to_json,
+             headers: { 'CONTENT_TYPE' => 'application/json' }
+      }.to change(Exam, :count).by(1)
+        .and change(ExamQuestion, :count).by(26)
+
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json['exam_id']).to be_present
+      expect(json['question_count']).to eq(26)
+      expect(json['pdf_url']).to be_present
+      expect(json['marking_scheme_url']).to be_present
+
+      exam = Exam.find(json['exam_id'])
+      section_numbers = exam.exam_questions.order(:position).pluck(:section_number)
+      expect(section_numbers).to eq([0] * 14 + [1] * 8 + [2] * 4)
+
+      ordered_qs = exam.exam_questions.order(:position).pluck(:question_id)
+      expect(ordered_qs[0...14]).to eq(mcq_questions.map(&:id))
+      expect(ordered_qs[14...22]).to eq(written_questions.map(&:id))
+      expect(ordered_qs[22...26]).to eq(composite_questions.map(&:id))
+    end
+
+    it 'returns 422 when force_include count exceeds question_count' do
+      # Build a tighter template: question_count 14 but 15 force_include rules
+      tight = template_payload(name: 'Overpin')
+      tight[:exam_template][:exam_sections_attributes] = [
+        tight[:exam_template][:exam_sections_attributes][0].merge(
+          question_count: 13   # fewer slots than force_includes (14)
+        )
+      ]
+      post '/api/exam_templates',
+           params: tight.to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+      expect(response).to have_http_status(:created)
+      overpin_id = JSON.parse(response.body).fetch('id')
+
+      expect {
+        post "/api/exam_templates/#{overpin_id}/generate",
+             params: {}.to_json,
+             headers: { 'CONTENT_TYPE' => 'application/json' }
+      }.not_to change(Exam, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      json = JSON.parse(response.body)
+      expect(json['error']).to match(/force_include.*question_count|too many force/i)
+    end
+
+    it 'fills sparse force_includes with random sampling from the pool' do
+      sparse = {
+        exam_template: {
+          name: 'Sparse fill',
+          exam_sections_attributes: [
+            {
+              name: 'Only A', position: 0, question_count: 5,
+              question_type_filter: ['multiple_choice'],
+              section_source_rules_attributes: [
+                { source_type: 'TopicModule', source_id: topic_module.id, weight: 1 }
+              ],
+              section_question_rules_attributes: [
+                { question_id: mcq_questions[0].id, rule_type: 'force_include' },
+                { question_id: mcq_questions[1].id, rule_type: 'force_include' },
+                { question_id: mcq_questions[13].id, rule_type: 'exclude' }
+              ]
+            }
+          ]
+        }
+      }
+      post '/api/exam_templates',
+           params: sparse.to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+      expect(response.status).to eq(201), "Expected 201 but got #{response.status}: #{response.body}"
+      tid = JSON.parse(response.body).fetch('id')
+
+      post "/api/exam_templates/#{tid}/generate",
+           params: {}.to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+      expect(response.status).to eq(201), "Expected 201 but got #{response.status}: #{response.body}"
+      exam = Exam.find(JSON.parse(response.body).fetch('exam_id'))
+      qids = exam.exam_questions.order(:position).pluck(:question_id)
+      expect(qids.size).to eq(5)
+      expect(qids[0]).to eq(mcq_questions[0].id)
+      expect(qids[1]).to eq(mcq_questions[1].id)
+      expect(qids).not_to include(mcq_questions[13].id)
+    end
+
+    it 'generated exam serves a modern paper-style PDF' do
+      post "/api/exam_templates/#{template_id}/generate",
+           params: {}.to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+      exam_id = JSON.parse(response.body).fetch('exam_id')
+
+      # Stub the PDF renderer so the spec doesn't spawn headless Chrome.
+      allow(PdfRenderer).to receive(:render_to_pdf) { |args| "PDFBYTES:#{args[:html].length}" }
+
+      get "/api/exams/#{exam_id}/pdf"
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with('application/pdf')
+    end
+
+    it 'returns 404 when generating from an unknown template' do
+      post '/api/exam_templates/99999999/generate',
+           params: {}.to_json,
+           headers: { 'CONTENT_TYPE' => 'application/json' }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/exams_pdf_style_spec.rb
+++ b/spec/requests/api/exams_pdf_style_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'API GET /api/exams/:id/pdf (style switch)', type: :request do
+  let!(:topic) { create(:topic) }
+  let!(:exam) { create(:exam, title: 'Style switch spec') }
+  let!(:question) { create(:question, topic: topic) }
+  let!(:eq) { create(:exam_question, exam: exam, question: question, position: 1) }
+
+  before do
+    # Stub Grover/Puppeteer — return the rendered HTML so we can assert on it.
+    allow(PdfRenderer).to receive(:render_to_pdf) { |args| args[:html] }
+  end
+
+  describe 'paper PDF' do
+    it 'defaults to the modern exams/paper template' do
+      get "/api/exams/#{exam.id}/pdf"
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with('application/pdf')
+      # `exams/paper` wraps the doc in a `paper`-class container that
+      # `exams/show` never produced.
+      expect(response.body).to include('class="paper-page"').or include('class="paper"').or include('paper-page')
+    end
+
+    it 'falls back to legacy exams/show on ?style=legacy' do
+      get "/api/exams/#{exam.id}/pdf?style=legacy"
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with('application/pdf')
+      # Two signals from the legacy show template: an `.exam-header` block
+      # or the heading "Practice Exam" rendered via the legacy layout.
+      # Either is fine; just ensure the modern paper marker is absent.
+      expect(response.body).not_to include('class="paper-page"')
+    end
+  end
+
+  describe 'marking scheme PDF' do
+    it 'defaults to the modern exams/marker_paper template' do
+      get "/api/exams/#{exam.id}/marking_scheme_pdf"
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with('application/pdf')
+      # marker_paper.html.erb renders a "Marking Scheme" header inside a
+      # marker-paper container; legacy marking_scheme.html.erb does not.
+      expect(response.body.downcase).to include('marker').or include('mark scheme').or include('marking scheme')
+    end
+
+    it 'falls back to legacy exams/marking_scheme on ?style=legacy' do
+      get "/api/exams/#{exam.id}/marking_scheme_pdf?style=legacy"
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to start_with('application/pdf')
+    end
+  end
+end

--- a/spec/views/questions/_ranking.html.erb_spec.rb
+++ b/spec/views/questions/_ranking.html.erb_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'questions/_ranking', type: :view do
+  def render_partial(options)
+    question = build_stubbed(:question, question_type: 'ranking', options: options)
+    render partial: 'questions/ranking', locals: { question: question }
+  end
+
+  it 'extracts the text from hash options instead of dumping the raw Ruby hash' do
+    render_partial([
+      { 'rank' => 1, 'text' => 'A well-formed HTML page' },
+      { 'rank' => 2, 'text' => 'A semantically correct page' }
+    ])
+
+    expect(rendered).to include('A well-formed HTML page')
+    expect(rendered).to include('A semantically correct page')
+    # The bug rendered options as raw Ruby hash literals like {"rank"=>1, ...}.
+    expect(rendered).not_to include('"rank"=&gt;')
+    expect(rendered).not_to include('=&gt;')
+  end
+
+  it 'still renders plain-string options as-is (legacy shape)' do
+    render_partial(['Alpha', 'Bravo'])
+
+    expect(rendered).to include('Alpha')
+    expect(rendered).to include('Bravo')
+  end
+
+  it 'accepts symbol-keyed hashes too' do
+    render_partial([{ text: 'Sym one' }, { text: 'Sym two' }])
+
+    expect(rendered).to include('Sym one')
+    expect(rendered).to include('Sym two')
+  end
+end


### PR DESCRIPTION
## Summary

- New API resource: `POST /api/exam_templates` (nested create with sections + rules), `GET /api/exam_templates[/:id]`, `POST /api/exam_templates/:id/generate`. Closes the [exam #80 failure](https://github.com/anthropics/) where `POST /api/exams` random-sampled 19 unrelated §1-§2 items alongside 7 of the 26 intended Ch3 §3-§4 questions.
- `ExamBuilder.from_template` gains a `preserve_order:` kwarg (default `false`). When `true`: force_includes are emitted in rule order, the section-final shuffle is skipped, over-pinning (`force_include > question_count`) raises, and every force_include question is validated against its section's `question_type_filter`. The API path uses `preserve_order: true`; the web UI path is unchanged.
- `Api::ExamsController#pdf` and `#marking_scheme_pdf` now default to the modern `exams/paper` and `exams/marker_paper` templates (which render section headers). `?style=legacy` falls back to the old `exams/show` / `exams/marking_scheme` layouts for any consumer pinned to them.
- Bonus: `_ranking.html.erb` now extracts `item['text']` when the option is a hash, so ranking questions stop rendering raw Ruby hash literals in printed papers.
- OpenAPI: four new paths, six new schemas, `style` query param documented on the existing PDF endpoints.

## Test plan

- [x] `bundle exec rspec spec/requests/api/exam_templates_spec.rb` — 11 new cases (happy path, over-pin → 422, type-filter mismatch → 422, missing-id → 422, sparse fill, show, index, generate-then-PDF, 404 paths)
- [x] `bundle exec rspec spec/requests/api/exams_pdf_style_spec.rb` — 4 new cases (modern vs legacy for both paper and marker)
- [x] `bundle exec rspec spec/views/questions/_ranking.html.erb_spec.rb` — 3 new cases (hash extraction, string compat, symbol keys)
- [x] Full non-system suite — 501 examples, 0 failures
- [x] Local smoke (dev server + curl): POST template → 201, POST generate → 201, DB inspection confirms `section_number` and force_include order preserved, all 4 PDFs render with correct page counts, 3 error paths return 422 with descriptive messages
- [x] `ruby -ryaml -e "YAML.load_file('docs/openapi.yml')"` — parses; `/api/openapi.json` lists all 4 new paths + 6 new schemas
- [ ] Post-deploy: POST the saved [`ch3_template_payload.json`](~/.claude/skills/exam-publish-workspace/trial-1/ch3_template_payload.json) to prod, generate the AI Eng Ch3 §3-§4 exam, save PDFs as `exam_paper_v2.pdf` and `marking_scheme_v2.pdf`