### PR TITLE
fix(topic_modules): auto-assign position so API module-create stops 500ing

### DIFF
--- a/app/models/topic_module.rb
+++ b/app/models/topic_module.rb
@@ -6,9 +6,20 @@ class TopicModule < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :topic_id, message: "already exists for this topic" }
   validates :position, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
 
+  before_validation :assign_default_position, on: :create, if: -> { position.blank? }
+
   scope :ordered, -> { order(position: :asc) }
 
   def categories
     learning_objectives.pluck(:category).compact.uniq.sort
+  end
+
+  private
+
+  # `position` is NOT NULL with no DB default and is not in the controller's
+  # permitted params, so an API-created module (name only) would otherwise hit a
+  # NotNullViolation. Default it to the next slot within the owning topic.
+  def assign_default_position
+    self.position = (TopicModule.where(topic_id: topic_id).maximum(:position) || 0) + 1
   end
 end

--- a/spec/requests/api/topic_modules_spec.rb
+++ b/spec/requests/api/topic_modules_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'API POST /api/topics/:topic_id/topic_modules', type: :request do
+  let!(:topic) { create(:topic) }
+
+  def create_module(name)
+    post "/api/topics/#{topic.id}/topic_modules",
+         params: { topic_module: { name: name } }.to_json,
+         headers: { 'Content-Type' => 'application/json' }
+  end
+
+  it 'creates a module from only a name and auto-assigns a position' do
+    expect {
+      create_module('Ch 9 §9.1 revised')
+    }.to change(TopicModule, :count).by(1)
+
+    expect(response).to have_http_status(:created)
+    json = JSON.parse(response.body)
+    expect(json['name']).to eq('Ch 9 §9.1 revised')
+    expect(TopicModule.find(json['id']).position).to be_present
+  end
+
+  it 'assigns the next sequential position within the topic' do
+    create(:topic_module, topic: topic, position: 1)
+    create(:topic_module, topic: topic, position: 2)
+
+    create_module('next module')
+
+    expect(response).to have_http_status(:created)
+    expect(TopicModule.find(JSON.parse(response.body)['id']).position).to eq(3)
+  end
+end


### PR DESCRIPTION
## Problem

`POST /api/topics/:topic_id/topic_modules` returns **500** on every call:

```
PG::NotNullViolation: null value in column "position" of relation "topic_modules" violates not-null constraint
```

`topic_modules.position` is `NOT NULL` with no DB default, but the controller only
permits `:name, :description` and nothing assigns `position` — so `@module.save`
always raises. (Model validation is `allow_nil: true`, so it passes validation and
fails at the DB layer → unhandled 500, not a 422.)

Discovered while trying to create a module via the API to hold a regenerated
DDIA Ch 9 §9.1 question set.

## Fix

Add a `before_validation` that defaults `position` to the next slot within the
owning topic when it's blank — matching the existing 1-indexed sequential
positions (Ch modules are 1..14). API callers that send only a name now work;
callers that pass an explicit position are unaffected.

## Tests

New request spec `spec/requests/api/topic_modules_spec.rb`:
- name-only create → 201 + position auto-assigned (fails RED with the exact NotNullViolation before the fix)
- sequential positioning within a topic (existing 1,2 → new 3)

`bundle exec rspec spec/requests/api/topic_modules_spec.rb spec/models` → 116 examples, 0 failures.